### PR TITLE
fix: permission issues for creating Flutter config directory

### DIFF
--- a/sdk/Dockerfile
+++ b/sdk/Dockerfile
@@ -12,28 +12,35 @@ LABEL org.opencontainers.image.licenses MIT
 ENV DOCKER_USER flutter
 ENV FLUTTER_DIR /home/${DOCKER_USER}
 
-RUN set -eux; mkdir -p ${FLUTTER_DIR}
+RUN set -eux; \
+  groupadd -r ${DOCKER_USER} && \
+  useradd -r -g ${DOCKER_USER} -d ${FLUTTER_DIR} ${DOCKER_USER} && \
+  mkdir -p ${FLUTTER_DIR} && \
+  chown ${DOCKER_USER}:${DOCKER_USER} ${FLUTTER_DIR}
+
 ENV PATH "$PATH:$FLUTTER_DIR/flutter/bin"
 
-RUN set -eux; groupadd -r ${DOCKER_USER} \
-  && useradd -r -g ${DOCKER_USER} ${DOCKER_USER}
+RUN set -eux; \
+  apt-get update && apt-get upgrade -y && \
+  apt-get install clang cmake ninja-build pkg-config libgtk-3-dev -y --no-install-recommends && \
+  curl -o ${DOCKER_USER}.tar.xz https://storage.googleapis.com/flutter_infra_release/releases/${FLUTTER_CHANNEL}/linux/flutter_linux_${FLUTTER_VERSION}.tar.xz && \
+  mv ${DOCKER_USER}.tar.xz ${FLUTTER_DIR} && \
+  cd ${FLUTTER_DIR} && \
+  tar xf ${DOCKER_USER}.tar.xz && \
+  rm ${DOCKER_USER}.tar.xz && \
+  git config --global --add safe.directory ${FLUTTER_DIR}/flutter && \
+  apt-get autoremove -y && \
+  apt-get autoclean -y
 
-RUN set -eux; apt-get update && apt-get upgrade -y \ 
-  && apt-get install clang cmake ninja-build pkg-config libgtk-3-dev -y --no-install-recommends \
-  && curl https://storage.googleapis.com/flutter_infra_release/releases/${FLUTTER_CHANNEL}/linux/flutter_linux_${FLUTTER_VERSION}.tar.xz -o ${DOCKER_USER}.tar.xz \
-  && mv ${DOCKER_USER}.tar.xz ${FLUTTER_DIR} \
-  && cd ${FLUTTER_DIR} \
-  && tar xf ${DOCKER_USER}.tar.xz \
-  && rm ${DOCKER_USER}.tar.xz \
-  && git config --global --add safe.directory ${FLUTTER_DIR}/${DOCKER_USER} \
-  && chown -R ${DOCKER_USER}:${DOCKER_USER} ${FLUTTER_DIR}/${DOCKER_USER} \
-  && apt-get autoremove \
-  && apt-get autoclean
+RUN set -eux; \
+  mkdir -p ${FLUTTER_DIR}/.config/flutter && \
+  chown -R ${DOCKER_USER}:${DOCKER_USER} ${FLUTTER_DIR}
 
 USER ${DOCKER_USER}
 
-RUN set -eux; yes | flutter doctor --android-licenses \
-  && flutter config --no-analytics \
-  && flutter doctor -v
+RUN set -eux; \
+  yes | flutter doctor --android-licenses && \
+  flutter config --no-analytics && \
+  flutter doctor -v
 
 CMD ["flutter"]


### PR DESCRIPTION
- Ensure the flutter user owns the `/home/flutter directory`
- Create and set permissions for the `/home/flutter/.config/flutter directory`
- Consolidate `chown` commands for proper ownership

This resolves the error where Flutter failed to create a directory at `/home/flutter/.config/flutter`.